### PR TITLE
Set disable_if_not_dependency to avoid linting projects not using XO

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -30,6 +30,10 @@ class XO(NodeLinter):
         'javascript (jsx)',
         'jsx-real'
     )
+    defaults = {
+        'enable_if_dependency': True,
+        'disable_if_not_dependency': True
+    }
     version_args = '--version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>=0.5.0'


### PR DESCRIPTION
Hi!

Fixes https://github.com/sindresorhus/SublimeLinter-contrib-xo/issues/5.

It has fixed it for me locally, it automatically sets those default settings to my Sublime Linter config:
<img width="371" alt="screen shot 2016-09-12 at 10 59 58" src="https://cloud.githubusercontent.com/assets/976570/18432086/1c5567e8-78d8-11e6-9a08-b61dac806f8b.png">
so I can actually change them manually if I want to.

FYI, I found these lines here https://github.com/zekesonxx/SublimeLinter-contrib-spider/blob/master/linter.py#L34-L37
