### PR TITLE
Implement automatic selector if plugins are used

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -8,10 +8,12 @@ from SublimeLinter.lint.base_linter.node_linter import read_json_file
 
 STANDARD_SELECTOR = 'source.js'
 PLUGINS = {
+	'eslint-plugin-html': 'text.html',
+	'eslint-plugin-json': 'source.json',
+	'eslint-plugin-markdown': 'text.html.markdown',
 	'eslint-plugin-svelte3': 'text.html',
 	'eslint-plugin-vue': 'text.html.vue',
-	'eslint-plugin-json': 'source.json',
-	'eslint-plugin-html': 'text.html'
+	'@typescript-eslint/parser': 'source.ts',
 }
 OPTIMISTIC_SELECTOR = ', '.join({STANDARD_SELECTOR} | set(PLUGINS.values()))
 

--- a/linter.py
+++ b/linter.py
@@ -1,4 +1,20 @@
+import os
 from SublimeLinter.lint import NodeLinter
+
+# TODO Proper export these in SL core
+from SublimeLinter.lint.linter import PermanentError
+from SublimeLinter.lint.base_linter.node_linter import read_json_file
+
+
+STANDARD_SELECTOR = 'source.js'
+PLUGINS = {
+	'eslint-plugin-svelte3': 'text.html',
+	'eslint-plugin-vue': 'text.html.vue',
+	'eslint-plugin-json': 'source.json',
+	'eslint-plugin-html': 'text.html'
+}
+OPTIMISTIC_SELECTOR = ', '.join({STANDARD_SELECTOR} | set(PLUGINS.values()))
+
 
 class XO(NodeLinter):
 	npm_name = 'xo'
@@ -10,6 +26,48 @@ class XO(NodeLinter):
 		r' \((?P<code>.+)\)$'
 	)
 	defaults = {
-		'selector': 'source.js - meta.attribute-with-value',
+		'selector': OPTIMISTIC_SELECTOR,
 		'disable_if_not_dependency': True
 	}
+
+	def run(self, cmd, code):
+		self.ensure_plugin_installed()
+		return super().run(cmd, code)
+
+	def ensure_plugin_installed(self) -> bool:
+		# If the user changed the selector, we take it as is
+		if self.settings['selector'] != OPTIMISTIC_SELECTOR:
+			return True
+
+		# Happy path.
+		if self.view.match_selector(0, STANDARD_SELECTOR):
+			return True
+
+		# If we're here we must be pessimistic.
+
+		# The 'project_root' has the relevant 'package.json' file colocated.
+		# If we fallback to a global installation there is no 'project_root',
+		# t.i. no auto-selector in that case as well.
+		project_root = self.context.get('project_root')
+		if project_root:
+			# We still need to be careful, in case SL deduced a 'project_root'
+			# without checking for the 'package.json' explicitly. Basically, a
+			# happy path for SL core.
+			manifest_file = os.path.join(project_root, 'package.json')
+			try:
+				manifest = read_json_file(manifest_file)
+			except Exception:
+				pass
+			else:
+				defined_plugins = PLUGINS.keys() & (
+					manifest.get('dependencies', {}).keys()
+					| manifest.get('devDependencies', {}).keys()
+				)
+				selector = ', '.join(PLUGINS[name] for name in defined_plugins)
+				if selector and self.view.match_selector(0, selector):
+					return True
+
+		# Indicate an error which usually can only be solved by changing
+		# the environment. Silently, do not notify and disturb the user!
+		self.notify_unassign()
+		raise PermanentError()

--- a/linter.py
+++ b/linter.py
@@ -1,7 +1,7 @@
 import os
 from SublimeLinter.lint import NodeLinter
 
-# TODO Proper export these in SL core
+# TODO: Properly export these in SL core: https://github.com/SublimeLinter/SublimeLinter/issues/1713
 from SublimeLinter.lint.linter import PermanentError
 from SublimeLinter.lint.base_linter.node_linter import read_json_file
 
@@ -37,7 +37,7 @@ class XO(NodeLinter):
 		return super().run(cmd, code)
 
 	def ensure_plugin_installed(self) -> bool:
-		# If the user changed the selector, we take it as is
+		# If the user changed the selector, we take it as is.
 		if self.settings['selector'] != OPTIMISTIC_SELECTOR:
 			return True
 
@@ -47,14 +47,14 @@ class XO(NodeLinter):
 
 		# If we're here we must be pessimistic.
 
-		# The 'project_root' has the relevant 'package.json' file colocated.
-		# If we fallback to a global installation there is no 'project_root',
+		# The `project_root` has the relevant `package.json` file colocated.
+		# If we fallback to a global installation there is no `project_root`,
 		# t.i. no auto-selector in that case as well.
 		project_root = self.context.get('project_root')
 		if project_root:
-			# We still need to be careful, in case SL deduced a 'project_root'
-			# without checking for the 'package.json' explicitly. Basically, a
-			# happy path for SL core.
+			# We still need to be careful, in case SublimeLinter deduced a `project_root`
+			# without checking for the `package.json` explicitly. Basically, a
+			# happy path for SublimeLinter core.
 			manifest_file = os.path.join(project_root, 'package.json')
 			try:
 				manifest = read_json_file(manifest_file)

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ In order for `xo` to be executed by SublimeLinter, you must ensure that its path
 
 ### Using non-JS syntax
 
-Typical plugins for Eslint, e.g. for TypeScript or Vue, should just work automatically if they're installed locally to your project. (Technically speaking: if they're defined in the same `package.json`.)
+Typical plugins for ESLint, for example, for TypeScript or Vue, should just work automatically if they're installed locally in your project (defined in the same `package.json`).
 
 For plugins not supported out-of-the-box, you may need to change the SublimeLinter [`selector` setting](http://www.sublimelinter.com/en/stable/linter_settings.html#selector) to include the correct syntax scope. For Vue, that could be:
 
@@ -46,7 +46,7 @@ For plugins not supported out-of-the-box, you may need to change the SublimeLint
 
 ### Help, `xo` doesn't lint my HTML files anymore!
 
-`xo` will only lint '*.js' files for standard, vanilla configurations without further plugins. Either install the "eslint-plugin-html" or tweak the `selector`: 
+`xo` will only lint `*.js` files for standard, vanilla config without further plugins. Either install the [eslint-plugin-html](https://github.com/BenoitZugmeyer/eslint-plugin-html) or tweak the `selector`: 
 
 ```json
 {

--- a/readme.md
+++ b/readme.md
@@ -30,13 +30,29 @@ In order for `xo` to be executed by SublimeLinter, you must ensure that its path
 
 ### Using non-JS syntax
 
-If you're using an ESLint plugin with XO that provides non-JS syntax, like TypeScript, Vue, etc, you need to change the SublimeLinter [`selector` setting](http://www.sublimelinter.com/en/stable/linter_settings.html#selector) to include the syntax scope. For Vue, that would be:
+Typical plugins for Eslint, e.g. for TypeScript or Vue, should just work automatically if they're installed locally to your project. (Technically speaking: if they're defined in the same `package.json`.)
+
+For plugins not supported out-of-the-box, you may need to change the SublimeLinter [`selector` setting](http://www.sublimelinter.com/en/stable/linter_settings.html#selector) to include the correct syntax scope. For Vue, that could be:
 
 ```json
 {
 	"linters": {
 		"xo": {
 			"selector": "text.html.vue, source.js - meta.attribute-with-value"
+		}
+	}
+}
+```
+
+### Help, `xo` doesn't lint my HTML files anymore!
+
+`xo` will only lint '*.js' files for standard, vanilla configurations without further plugins. Either install the "eslint-plugin-html" or tweak the `selector`: 
+
+```json
+{
+	"linters": {
+		"xo": {
+			"selector": "source.js - meta.attribute-with-value"
 		}
 	}
 }


### PR DESCRIPTION
Fixes #16

The strategy here is to use a wide `selector` in the beginning and
then narrow it down during actual linting.

SublimeLinter needs a good `selector` as a **fast** check to match
views and installed linters because this first check runs on a shared
worker. T.i. we cannot just select *all* views and then decide later.

After the first check, it is always possible to abort loud or silently.
We do here silently because it's not a configuration error coming
from the user but an automatic algorithm bailing out.

With this implementation there comes the drawback that we have to flip
the previous default behavior. The default behavior was for the linter
to run on parts of the buffer marked as `source.js` concurrently. E.g.
it did run on the `<script>` tags when viewing a HTML file.

However, this default often did not produce good results. I.e. in an
HTML file it has no notion of gloabls introduced in one script which
are accessible in another script.

If the user wants this behavior, she now has to opt in by setting the
old selector `'source.js - meta.attribute-with-value'` in the settings
on her own.

Implementation risks:

- We deep import `read_json_file`. It is possible that this import can
  break since deep imports are not protected by any deprecation policy.

- We have two side-effects: `self.notify_unassign()` followed by
  `raise PermanentError()`. It is possible that in the future we need
  to signal the same outcome differently.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#16: Automatically configure alternative syntax scopes when available](https://issuehunt.io/repos/40055697/issues/16)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->