### PR TITLE
Fix deprecation

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -38,7 +38,6 @@ def plugin_loaded():
 	settings = sublime.load_settings('SublimeLinterContribXO.sublime-settings')
 
 class XO(NodeLinter):
-	npm_name = 'xo'
 	cmd = ('xo', '--stdin', '--reporter', 'compact', '--filename', '${file}')
 	regex = (
 		r'^.+?: line (?P<line>\d+), col (?P<col>\d+), '


### PR DESCRIPTION
Using package v3.2.1 with SublimeLinter 4.16.2 in Sublime Text 3.2.2 build 3211 x64

I've noticed the following error in Console at every ST launch:
`xo: Defining 'cls.npm_name' has no effect. Please cleanup and remove this setting.`.

Based on this related PR https://github.com/SublimeLinter/SublimeLinter-stylelint/pull/14 (per https://github.com/SublimeLinter/SublimeLinter-stylelint/issues/13)
removing the npm name fixes the issue.